### PR TITLE
Correcting a typo.

### DIFF
--- a/EdgeFixer/vsplugin.c
+++ b/EdgeFixer/vsplugin.c
@@ -44,7 +44,7 @@ static const VSFrameRef * VS_CC vs_continuity_get_frame(int n, int activationRea
 		
 		for (i = 0; i < data->top; ++i) {
 			int ref_row = data->top - i;
-			edgefixer_process_edge(ptr + stride * (ref_row - i), ptr + stride * ref_row, 1, 1, data->vi.width, data->radius, tmp);
+			edgefixer_process_edge(ptr + stride * (ref_row - 1), ptr + stride * ref_row, 1, 1, data->vi.width, data->radius, tmp);
 		}
 		for (i = 0; i < data->bottom; ++i) {
 			int ref_row = data->vi.height - data->bottom - 1 + i;


### PR DESCRIPTION
I can't be 100% but this looks totally like a typo.
All the other sides get a -1 displacement on the src pointer, but only the top one get a -i displacement, also don't make much sense to me.

Waiting clarification.